### PR TITLE
Default to null server status handler

### DIFF
--- a/lib/dictate.js
+++ b/lib/dictate.js
@@ -63,7 +63,6 @@
 		config.onEndOfSession = config.onEndOfSession || function() {};
 		config.onEvent = config.onEvent || function(e, data) {};
 		config.onError = config.onError || function(e, data) {};
-		config.onServerStatus = config.onServerStatus || {};
 		config.rafCallback = config.rafCallback || function(time) {};
 		if (config.onServerStatus) {
 			monitorServerStatus();


### PR DESCRIPTION
The rest of the code assumes server status will be a function or false-ish, so defaulting to an object breaks some parts of the code if a server status callback isn't defined in the options.