### PR TITLE
Narrow scope of Dictate's private variables

### DIFF
--- a/lib/dictate.js
+++ b/lib/dictate.js
@@ -39,15 +39,6 @@
 		9: 'No available', // recognizer processes are currently in use and recognition cannot be performed
 	};
 
-	// Initialized by init()
-	var audioContext;
-	var recorder;
-	// Initialized by startListening()
-	var ws;
-	var intervalKey;
-	// Initialized during construction
-	var wsServerStatus;
-
 	var Dictate = function(cfg) {
 		var config = cfg || {};
 		config.server = config.server || SERVER;
@@ -68,6 +59,15 @@
 		if (config.onServerStatus) {
 			monitorServerStatus();
 		}
+
+		// Initialized by init()
+		var audioContext;
+		var recorder;
+		// Initialized by startListening()
+		var ws;
+		var intervalKey;
+		// Initialized during construction
+		var wsServerStatus;
 
 		// Returns the configuration
 		this.getConfig = function() {


### PR DESCRIPTION
Currently the scope of variables like audioContext means that multiple instances of Dictate will overwrite the other instances' copy. Scoping them to the constructor has the same availability internally but keeps them per-instance.