### PR TITLE
MediaStreamAudioSourceNode cycle collection

### DIFF
--- a/lib/dictate.js
+++ b/lib/dictate.js
@@ -202,7 +202,10 @@
 		function startUserMedia(stream) {
 			var input = audioContext.createMediaStreamSource(stream);
 			config.onEvent(MSG_MEDIA_STREAM_CREATED, 'Media stream created');
-
+                        //Firefox loses the audio input stream every five seconds
+                        // To fix added the input to window.source
+                        window.source = input;
+                        
 			// make the analyser available in window context
 			window.userSpeechAnalyser = audioContext.createAnalyser();
 			input.connect(window.userSpeechAnalyser);


### PR DESCRIPTION
MediaStreamAudioSourceNode cycle collection happening too soon with getUserMedia in firefox almost every 5 seconds (approx)